### PR TITLE
updated initState() on _MyHomePageState

### DIFF
--- a/fittrack_ui/lib/screens/home_screen.dart
+++ b/fittrack_ui/lib/screens/home_screen.dart
@@ -58,10 +58,10 @@ class _MyHomePageState extends State<MyHomePage> {
           biometricdata['$key'] = value;
         }
       });
-      setState(() {});
     } catch (e) {
       result = 'readAll: $e';
     }
+    setState(() {});
   }
 
   //TODO 使ってなさそう せっかくなので権限を無効にできる機能が使えても良いかな

--- a/fittrack_ui/lib/screens/home_screen.dart
+++ b/fittrack_ui/lib/screens/home_screen.dart
@@ -29,11 +29,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-    // TODO このメソッドは特に必要なさそうに見えます
-    fetchPermissions();
     read();
-    // TODO read()の結果 biometricdataを反映させるためには setState()なので もう一度buildさせる必要があると思います。
-    // TODO initStateとbuildは非同期で呼ばれる為
   }
 
   Future<void> read() async {
@@ -62,6 +58,7 @@ class _MyHomePageState extends State<MyHomePage> {
           biometricdata['$key'] = value;
         }
       });
+      setState(() {});
     } catch (e) {
       result = 'readAll: $e';
     }


### PR DESCRIPTION
# 目的
_MyHomePageStateクラスのinitState()に不要な処理の削除、生体データ取得後のrebuildをしていなかったため修正

# やったこと
- home_screen.dart＞_MyHomePageStateクラスのinitState()でfetchpermission()を削除
- read()メソッドの最後にsetStateを追加。try文の後に追加し、read()後に常にrebuildされるようにした。
- 動作確認（read()後のrebuildの処理が入った。エラーなし）

## 解決したTodo
- このメソッドは特に必要なさそうに見えます→削除して対応
- read()の結果 biometricdataを反映させるためには setState()なので もう一度buildさせる必要があると思います。initStateとbuildは非同期で呼ばれる為→read()の最後の処理にsetState()を追加することで対応

# 不安に思っていること
- setState()をread()メソッド内に入れることはflutterの動作に影響はないのか？