### PR TITLE
Positionに関する実験

### DIFF
--- a/fittrack_ui/lib/screens/home_screen.dart
+++ b/fittrack_ui/lib/screens/home_screen.dart
@@ -174,7 +174,6 @@ class _MyHomePageState extends State<MyHomePage> {
 
   _buildMoodsHolder() {
     return Positioned(
-      //Todo lib/screens/home_screen.dart のL:215でbottom: -45となっていますが、画面サイズが違う場合に期待するUIになるのか気になりました。iPhone 12 Pro Max とiPhone SEなど
       bottom: -45,
       child: Container(
         height: 100,


### PR DESCRIPTION
# 目的
_buildMoodsHolder()内のPositionに関して、画面の大きな端末、小さな端末で想定通りになっているか実験

# やったこと
- 動作確認（iPhone 12 Pro Max, iPhone se）
<img width="894" alt="スクリーンショット 2021-06-10 10 40 44" src="https://user-images.githubusercontent.com/73813855/121451341-5f10fd80-c9d8-11eb-9352-18b5085daa23.png">

## 解決したTodo
lib/screens/home_screen.dart のL:215でbottom: -45となっていますが、画面サイズが違う場合に期待するUIになるのか気になりました。iPhone 12 Pro Max とiPhone SEなど→確認したところ想定通りだったためそのまま

# 不安に思っていること
特になし