### PR TITLE
biometricdataがnullのときに落ちてしまう問題解決完了

### DIFF
--- a/fittrack_ui/lib/screens/data_screen.dart
+++ b/fittrack_ui/lib/screens/data_screen.dart
@@ -33,10 +33,7 @@ class DataPage extends StatelessWidget {
     final double windowWidth = MediaQuery.of(context).size.width;
     final double windowHeight = MediaQuery.of(context).size.height;
     DateTime now = DateTime.now();
-    final heartspot = biometricdata['DataType.HEART_RATE']
-            .where((element) =>
-                element.dateTo.day == now.add(Duration(days: 0)).day)
-            .isEmpty
+    final heartspot = biometricdata['DataType.HEART_RATE']?.isEmpty ?? true
         ? [FlSpot(0, 40)]
         : biometricdata['DataType.HEART_RATE']
             .where((element) =>
@@ -46,9 +43,19 @@ class DataPage extends StatelessWidget {
                 e.dateTo.hour.toDouble() + (e.dateTo.minute / 60).toDouble(),
                 e.value.toDouble()))
             .toList();
-    final steps = biometricdata['DataType.STEP_COUNT']
-        .map((e) => FlSpot(e.dateTo.weekday.toDouble(), e.value.toDouble()))
-        .toList();
+    final steps = biometricdata['DataType.STEP_COUNT']?.isEmpty ?? true
+        ? [
+            FlSpot(1, 2000),
+            FlSpot(2, 2000),
+            FlSpot(3, 2000),
+            FlSpot(4, 2000),
+            FlSpot(5, 2000),
+            FlSpot(6, 2000),
+            FlSpot(7, 2000)
+          ]
+        : biometricdata['DataType.STEP_COUNT']
+            .map((e) => FlSpot(e.dateTo.weekday.toDouble(), e.value.toDouble()))
+            .toList();
     List<FlSpot> stepspot = [];
     stepspot.add(steps
         .where((element) => element.x == 1)

--- a/fittrack_ui/lib/screens/home_screen.dart
+++ b/fittrack_ui/lib/screens/home_screen.dart
@@ -213,7 +213,6 @@ class _MyHomePageState extends State<MyHomePage> {
                 Navigator.push(
                     context,
                     MaterialPageRoute(
-                        // TODO データが取れていない状態で遷移すると落ちます
                         builder: (context) =>
                             DataPage(biometricdata: biometricdata)));
               }),
@@ -223,22 +222,22 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   _buildNextAppointmentInfo() {
-    final heartrate = biometricdata.isEmpty
+    final heartrate = biometricdata['DataType.HEART_RATE']?.isEmpty ?? true
         ? 0
         : biometricdata['DataType.HEART_RATE'].last.value.round();
-    final heartratetime = biometricdata.isEmpty
+    final heartratetime = biometricdata['DataType.HEART_RATE']?.isEmpty ?? true
         ? 0
         : biometricdata['DataType.HEART_RATE'].last.dateTo;
-    final steps = biometricdata.isEmpty
+    final steps = biometricdata['DataType.STEP_COUNT']?.isEmpty ?? true
         ? 0
         : biometricdata['DataType.STEP_COUNT'].last.value.round();
-    final stepstime = biometricdata.isEmpty
+    final stepstime = biometricdata['DataType.STEP_COUNT']?.isEmpty ?? true
         ? 0
         : biometricdata['DataType.STEP_COUNT'].last.dateTo;
-    final energy = biometricdata.isEmpty
+    final energy = biometricdata['DataType.ENERGY']?.isEmpty ?? true
         ? 0
         : biometricdata['DataType.ENERGY'].last.value.round();
-    final energytime = biometricdata.isEmpty
+    final energytime = biometricdata['DataType.ENERGY']?.isEmpty ?? true
         ? 0
         : biometricdata['DataType.ENERGY'].last.dateTo;
     return Container(


### PR DESCRIPTION
# 目的
- 次のエラーの解消。home_screen.dartでbiometricdataが取得できていない状態だと、home_screen.dartおよびdata_screen.dartで'bad state no element'というエラーが発生する。

# やったこと
- bitometricdataが取得できていない場合（初期値null）の、heartrate等の初期値を設定
- data_screen.dartでbiometricdataが渡されていない場合（初期値null）の、stepspotとheartspotの初期値を設定
- 動作確認（データがないIPhone 12 Pro Max, iPhone SE, Android実機）

## 解決したTodo
データが取れていない状態で遷移すると落ちます→初期値であるnullの場合落ちていたので、nullではない初期値設定

# 不安に思っていること
- flutter内の初期値に関してベストプラクティスはなにか？そもそもnullの場合の処理を分岐して書かせるのが良いのか？