### PR TITLE
comment for revokepermission()

### DIFF
--- a/fittrack_ui/lib/screens/home_screen.dart
+++ b/fittrack_ui/lib/screens/home_screen.dart
@@ -64,8 +64,7 @@ class _MyHomePageState extends State<MyHomePage> {
     setState(() {});
   }
 
-  //TODO 使ってなさそう せっかくなので権限を無効にできる機能が使えても良いかな
-  //TODO lib/screens/home_screen.dart の revokePermissions()  が使われている形跡がないのですが、必要なのでしょうか？
+  // データ同期権限をrevokeさせるメソッド。ログアウト機能実装時に使用する。
   Future<void> revokePermissions() async {
     results.clear();
     try {


### PR DESCRIPTION
# 目的
- revokepermissions()があるが使用していない、コメントもない状況のため

# やったこと
- コメントの付与。revokepermissionsはログアウト機能を実装時に実装するため。

## 解決したTodo
- 使ってなさそう せっかくなので権限を無効にできる機能が使えても良いかな→現状使用していないのでコメント付与して対応
- lib/screens/home_screen.dart の revokePermissions() が使われている形跡がないのですが、必要なのでしょうか？→実装予定の機能のためコメントを付与して残して対応

# 不安に思っていること
- 特になし