### PR TITLE
ログイン・サインアップ時のerror内容を表示するように変更

### DIFF
--- a/fittrack_ui/lib/screens/sign_in.dart
+++ b/fittrack_ui/lib/screens/sign_in.dart
@@ -460,9 +460,7 @@ class SignInButton extends StatelessWidget {
           'password': passEditingController.text,
         });
         if (response.statusCode != 201 && response.statusCode != 200) {
-          message.setMessage(
-              // TODO statusCodeではなく エラーの内容を出した方が良いと思う
-              'Request failed with status: ${response.statusCode}.');
+          message.setMessage('Request failed with status: ${response.body}.');
         } else if (response == null) {
           // ここは通らないかもしれなが念の為
           message.setMessage("入力内容を確認してください");
@@ -507,9 +505,7 @@ class SignupButton extends StatelessWidget {
           "password_confirmation": passEditingController.text
         });
         if (response.statusCode != 201 && response.statusCode != 200) {
-          message.setMessage(
-              // TODO statusCodeではなく エラーの内容を出した方が良いと思う
-              'Request failed with status: ${response.statusCode}.');
+          message.setMessage('Request failed with status: ${response.body}.');
         } else if (response == null) {
           // ここは通らないかもしれなが念の為
           message.setMessage("入力内容を確認してください");

--- a/fittrack_ui/lib/screens/sign_in.dart
+++ b/fittrack_ui/lib/screens/sign_in.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:convert';
 
 class SignIn extends StatefulWidget {
   final SignInType signInType;
@@ -459,8 +460,9 @@ class SignInButton extends StatelessWidget {
           'email': mailEditingController.text,
           'password': passEditingController.text,
         });
+        Map<String, dynamic> body = jsonDecode(response.body);
         if (response.statusCode != 201 && response.statusCode != 200) {
-          message.setMessage('Request failed with status: ${response.body}.');
+          message.setMessage('Request failed with status: ${body["errors"]}.');
         } else if (response == null) {
           // ここは通らないかもしれなが念の為
           message.setMessage("入力内容を確認してください");
@@ -504,8 +506,9 @@ class SignupButton extends StatelessWidget {
           'password': passEditingController.text,
           "password_confirmation": passEditingController.text
         });
+        Map<String, dynamic> body = jsonDecode(response.body);
         if (response.statusCode != 201 && response.statusCode != 200) {
-          message.setMessage('Request failed with status: ${response.body}.');
+          message.setMessage('Request failed with status: ${body["errors"]}.');
         } else if (response == null) {
           // ここは通らないかもしれなが念の為
           message.setMessage("入力内容を確認してください");


### PR DESCRIPTION
# 目的
ログイン・サインアップでエラー発生時にエラー内容を表示するように修正

# やったこと
- response.statusCode→response.bodyに変更

## 解決したTodo
- statusCodeではなく エラーの内容を出した方が良いと思う→そのように変更

# 不安に思っていること
bodyが以下のように出てきます。errorsのみ出力するのがベストでしょうか？その場合、bodyはString型なのですがどのようにparseするのが一般的ですか？
```
{"success":false, "errors":["invalid login credentials. Please try again."'}