### PR TITLE
使用していないPermission（Activity Recognition）の削除

### DIFF
--- a/fittrack_ui/android/app/src/debug/AndroidManifest.xml
+++ b/fittrack_ui/android/app/src/debug/AndroidManifest.xml
@@ -4,5 +4,4 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
 </manifest>

--- a/fittrack_ui/android/app/src/main/AndroidManifest.xml
+++ b/fittrack_ui/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,5 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
-    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
     <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>

--- a/fittrack_ui/android/app/src/profile/AndroidManifest.xml
+++ b/fittrack_ui/android/app/src/profile/AndroidManifest.xml
@@ -4,5 +4,4 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
 </manifest>


### PR DESCRIPTION
# 目的
- 使用していないPermissionがAndroidに存在していたので削除

# やったこと
- AndroidManifest.xmlのACTIVITY_RECOGNITIONのuses-permissionを削除した。
- 動作確認（今まで通り生体データを取得できた）

# 不安に思っていること
- AndroidManifest.xmlは3つファイルがあるがどのような違いがあるのか？