### PR TITLE
heartratespotがnullにならない初期条件式のアップデート

### DIFF
--- a/fittrack_ui/lib/screens/data_screen.dart
+++ b/fittrack_ui/lib/screens/data_screen.dart
@@ -33,7 +33,12 @@ class DataPage extends StatelessWidget {
     final double windowWidth = MediaQuery.of(context).size.width;
     final double windowHeight = MediaQuery.of(context).size.height;
     DateTime now = DateTime.now();
-    final heartspot = biometricdata['DataType.HEART_RATE']?.isEmpty ?? true
+    final heartspot = biometricdata['DataType.HEART_RATE']
+                .where((element) =>
+                    element.dateTo.day == now.add(Duration(days: 0)).day)
+                .toList()
+                .isEmpty ??
+            true
         ? [FlSpot(0, 40)]
         : biometricdata['DataType.HEART_RATE']
             .where((element) =>


### PR DESCRIPTION
# 目的
- data_screen.dartでheartspotがnullになる場合があったため修正

# やったこと
- 初期条件式をbiometricdata['DataType.HEART_RATE']?.isEmpty ?? trueから次に変更
```dart
biometricdata['DataType.HEART_RATE']
                .where((element) =>
                    element.dateTo.day == now.add(Duration(days: 0)).day)
                .toList()
                .isEmpty ??
            true
```

# 不安に思っていること
特になし